### PR TITLE
Test on newer versions of Postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,12 @@
 ---
 
-dist: trusty
+dist: focal
 sudo: true
 language: sql
 
 
 matrix:
   include:
-    - addons:
-        postgresql: 9.2
-        apt:
-          packages:
-            - postgresql-server-dev-9.2
-            - postgresql-9.2-pgtap
-      env:
-        - POSTGRESQL=9.2
-
-    - addons:
-        postgresql: 9.3
-        apt:
-          packages:
-            - postgresql-server-dev-9.3
-            - postgresql-9.3-pgtap
-      env:
-        - POSTGRESQL=9.3
-
-    - addons:
-        postgresql: 9.4
-        apt:
-          packages:
-            - postgresql-server-dev-9.4
-            - postgresql-9.4-pgtap
-      env:
-        - POSTGRESQL=9.4
-
-    - addons:
-        postgresql: 9.5
-        apt:
-          packages:
-            - postgresql-server-dev-9.5
-            - postgresql-9.5-pgtap
-      env:
-        - POSTGRESQL=9.5
-
     - addons:
         postgresql: 9.6
         apt:
@@ -51,7 +15,14 @@ matrix:
             - postgresql-9.6-pgtap
       env:
         - POSTGRESQL=9.6
-
+    - addons:
+        postgresql: 14.2
+        apt:
+          packages:
+            - postgresql-server-dev-14.2
+            - postgresql-14.2-pgtap
+      env:
+        - POSTGRESQL=14.2
 
 script:
   - make


### PR DESCRIPTION
We only need to support a few versions for this as it is only deployed on the LINZ geoservers and AIMS servers